### PR TITLE
Add 'review only' as an option

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -19,8 +19,8 @@
         }
         buttonHtml = '<span class="octicon octicon-git-branch-delete"></span> ' + (disabled ? 'Protected branch' : 'Delete branch');
       } else {
-        var wipTitleRegex = /[\[(^](do\s*n[o']?t\s*merge|wip|dnm)[\]):]/i;
-        var wipTagRegex = /(wip|do\s*not\s*merge|dnm)/i;
+        var wipTitleRegex = /[\[(^](do\s*n[o']?t\s*merge|review\s*only|wip|dnm)[\]):]/i;
+        var wipTagRegex = /(wip|do\s*not\s*merge|dnm|review\s*only)/i;
 
         var isWipTitle = wipTitleRegex.test(issueTitle);
         var isWipTaksList = $container.find('.timeline-comment:first input[type="checkbox"]:not(:checked)').length > 0;


### PR DESCRIPTION
This PR adds the ability to hide the "Merge" button on Github by specifying `[Review Only]` in the title (or as a tag) of a Pull Request.

Here's an example of some of the formats that will be recognized by the new regex:
![image](https://user-images.githubusercontent.com/6726985/33118784-396b7982-cfb0-11e7-8a59-40bfb575c3e9.png)

Here's an updated zip file to install in chrome and test (you must go to `chrome://extensions` and check `Developer Mode` in the top right corner first):
[do-not-merge.zip](https://github.com/etdev/do-not-merge-wip-for-github/files/1495295/do-not-merge.zip)

